### PR TITLE
Disabled checksum check for suricata i dockerfile

### DIFF
--- a/dockerfile/Dockerfile
+++ b/dockerfile/Dockerfile
@@ -32,6 +32,8 @@ url = http://rules.emergingthreats.net/open/suricata/emerging.rules.tar.gz' /etc
 RUN sed -ir 's|^classification-file: /etc/suricata/classification.config$|classification-file: /etc/suricata/rules/classification.config|' /etc/suricata/suricata.yaml
 RUN sed -ir 's|^reference-file: /etc/suricata/reference.config$|reference-file: /etc/suricata/rules/reference.config|' /etc/suricata/suricata.yaml
 RUN sed -ir 's|#- rule-reload: true|- rule-reload: true|' /etc/suricata/suricata.yaml
+RUN sed -ir 's|^  checksum-valdation: yes|  checksum-valdation: no|' /etc/suricata/suricata.yaml
+RUN sed -ir 's|^  checksum-checks: auto|  checksum-checks: no|' /etc/suricata/suricata.yaml
 RUN touch /etc/suricata/threshold.config
         
 RUN git clone https://github.com/pdelsante/pcapoptikon.git /opt/pcapoptikon && \


### PR DESCRIPTION
As stated in [docs](https://redmine.openinfosecfoundation.org/projects/suricata/wiki/Suricatayaml#Stream-engine) and also in `suricata.yaml`:
```
checksum-validation:
To validate the checksum of received packet. If csum validation is specified as "yes", then packet with invalid csum will not be processed by the engine stream/app layer.
Warning: locally generated trafic can be generated without checksum due to hardware offload of checksum. You can control the handling of checksum on a per-interface basis via the 'checksum-checks' option.
```
Also disabled checks on pcap file to remove some useless log.
